### PR TITLE
GitHub action to setup poetry

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2020 Sondre Lillebø Gundersen
+Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-This is an action which sets up poetry for a project that uses [Poetry](https://python-poetry.org/) to manage its dependencies.
-It requires a `poetry.lock` file to be present in the root of the repository. It:
+This is an action which sets up Python and poetry for a project that uses [Poetry](https://python-poetry.org/) to manage its dependencies.
+It requires a `poetry.lock` file to be present in the root of the repository. The action:
 
 - calls [`actions/setup-python`](https://github.com/actions/setup-python),
 - `pip`-installs `poetry`,
 - `poetry install`-s the current project,
 - uses [`actions/cache`](https://github.com/actions/cache) to cache the poetry installation and the virtual environment it manages.
 
-From the point, the caller of the action can run commands within the poetry-managed environment with `poetry run`.
+From this point, the caller of the action can run commands within the poetry-managed environment with `poetry run`.
+
+The Python and Poetry versions to are configurable: see `action.yaml` for details.
 
 This particular action is loosely based on [`snok/install-poetry`](https://github.com/snok/install-poetry): in particular, the advice from its README on handling caching.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+This is an action which sets up poetry for a project that uses [Poetry](https://python-poetry.org/) to manage its dependencies.
+It requires a `poetry.lock` file to be present in the root of the repository. It:
+
+- calls [`actions/setup-python`](https://github.com/actions/setup-python),
+- `pip`-installs `poetry`,
+- `poetry install`-s the current project,
+- uses [`actions/cache`](https://github.com/actions/cache) to cache the poetry installation and the virtual environment it manages.
+
+From the point, the caller of the action can run commands within the poetry-managed environment with `poetry run`.
+
+This particular action is loosely based on [`snok/install-poetry`](https://github.com/snok/install-poetry): in particular, the advice from its README on handling caching.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,83 @@
+name: Setup Python and Poetry
+description: Setup Python and Poetry. Cribbed from snok/install-poetry.
+inputs:
+  python-version:
+    description: Python version to pass to actions/setup-python@v2.
+    required: false
+    default: "3.x"
+  poetry-version:
+    description: Poetry version to install via pip.
+    required: false
+    default: "1.1.12"
+  debug:
+    description: If set to the string 'true', dump the state of the virtual env after setup.
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Setup Python
+      id: setup-python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Check for poetry lock
+      run: "test -f poetry.lock || (echo No lock file! && false)"
+      shell: bash
+
+    # Install poetry. It takes ~10seconds for a clean pip install, most of which is
+    # the installation rather than the downloading. So instead, we cache the user-base
+    # directory (~/.local). For this to be safe:
+    # - we must not write to `.local` as part of the CI
+    # - we must not install anything with the system `pip` other than poetry.
+    # Based on the writeup at:
+    # https://github.com/snok/install-poetry/blob/main/README.md#caching-the-poetry-installation
+    - name: Locate user site
+      id: site-user-base
+      run: echo "::set-output name=dir::$(python -m site --user-base)"
+      shell: bash
+
+    - name: Restore poetry installation
+      id: poetry-install-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.site-user-base.outputs.dir }}
+        key: poetry-install-cache-${{ steps.setup-python.outputs.python-version }}-${{ inputs.poetry-version }}
+
+    - name: Install poetry from scratch
+      if: "${{ steps.poetry-install-cache.outputs.cache-hit != 'true' }}"
+      run: python -m pip install --user poetry==${{ inputs.poetry-version }}
+      shell: bash
+
+    # Poetry manages a virtualenv for us. We're going to cache that too.
+    # Again, we're following snok/install-poetry's README.
+    - name: Locate poetry venv
+      id: poetry-venvs
+      run: echo "::set-output name=dir::$(python -m poetry config virtualenvs.path)"
+      shell: bash
+
+    - name: Restore poetry venv
+      id: poetry-venv-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.poetry-venvs.outputs.dir }}
+        key: poetry-venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Install dependencies
+      if: "${{ steps.poetry-venv-cache.outputs.cache-hit != 'true' }}"
+      run: poetry install --no-interaction --no-root
+      shell: bash
+
+    # (Not sure if this is needed if there's a cache hit?)
+    - name: Install project
+      run: poetry install --no-interaction
+      shell: bash
+
+    # For debugging---let's just check what we're working with.
+    - name: Dump virtual environment
+      if: "${{ inputs.debug == 'true' }}"
+      run: |
+        poetry env info
+        poetry show
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
       run: echo "::set-output name=dir::$(python -m site --user-base)"
       shell: bash
 
-    - name: Restore poetry installation
+    - name: Restore/cache poetry installation
       id: poetry-install-cache
       uses: actions/cache@v2
       with:
@@ -53,7 +53,7 @@ runs:
       run: echo "::set-output name=dir::$(python -m poetry config virtualenvs.path)"
       shell: bash
 
-    - name: Restore poetry venv
+    - name: Restore/cache poetry venv
       id: poetry-venv-cache
       uses: actions/cache@v2
       with:

--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: Poetry version to install via pip.
     required: false
     default: "1.1.12"
-  debug:
-    description: If set to the string 'true', dump the state of the virtual env after setup.
-    required: false
-    default: "false"
 runs:
   using: composite
   steps:
@@ -76,7 +72,6 @@ runs:
 
     # For debugging---let's just check what we're working with.
     - name: Dump virtual environment
-      if: "${{ inputs.debug == 'true' }}"
       run: |
         poetry env info
         poetry show


### PR DESCRIPTION
In getting Sydent's dependencies to be managed by poetry I have composed a reusable action `setup-python-poetry` which sets up poetry for CI to use. Other parts of the WIP changes in Sydent make use of this action, but this is the "lowest" build block with no dependencies. Therefore I'm putting it up for review first.

I did look at prior art here, mainly [`snok/install-poetry`](https://github.com/snok/install-poetry). But that action required the user to manually setup caching; I wanted that to Just Work (TM). There's also a PR [for `actions/setup-python`](https://github.com/actions/setup-python/pull/281) which proposes to add support for caching poetry installations. However, I think that is concerned with caching the poetry-managed venv only; I also wanted to cache the installation of poetry itself.

## Explanation

To see this in action, visit https://github.com/matrix-org/sydent/actions/runs/1752681044, which is part of https://github.com/matrix-org/sydent/pull/488. That is a Sydent PR which tests three layers of GitHub actions config:
1. In the Sydent PR itself, there is a single "pipeline" workflow which uses [two callable workflows in "backend-meta"](https://github.com/matrix-org/sydent/blob/9a66fec9698f1ca5634f1e4b1f039a16cd885b42/.github/workflows/pipeline.yml#L24-L29) and [the `setup-python-poetry` action](https://github.com/matrix-org/sydent/blob/9a66fec9698f1ca5634f1e4b1f039a16cd885b42/.github/workflows/pipeline.yml#L39-L44).
2. My branch in `backend-meta` contains two ["reusable workflows"](https://docs.github.com/en/actions/using-workflows/reusing-workflows): one for [linting a poetry project](https://github.com/matrix-org/backend-meta/blob/dmr/poetry-ci/.github/workflows/python-ci.yml), and one for [building wheels and sdists](https://github.com/matrix-org/backend-meta/blob/dmr/poetry-ci/.github/workflows/packaging.yml). It's not necessary to put these in another repo, but I want to try and provide reusable building blocks for other projects. The linter workflow uses [the `setup-python-poetry` action](https://github.com/matrix-org/backend-meta/blob/af1ee9f43a5fd50e0bf6b52a02ecf50398cfde7f/.github/workflows/python-ci.yml#L15-L16) too.
3. `setup-python-poetry` is the action defined in this repo and proposed in the current PR. 

`setup-python-poetry` is a ["composite action"](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action). It `pip`-installs poetry, then uses poetry to create a new virtual environment according to `pyproject.toml`. `actions/setup-python` does the hard work for us, but we make use of`actions/cache` to avoid having to re-install poetry and the project unless the python version, poetry version, or the lockfile has changed between CI runs.  

After using this action, subsequent job steps can use `poetry run foo [...]` to run `foo [...]` in the virtual environment.

If accepted, [best practice for actions](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management) says we should make a release branch and tag the appropriate version as `v1`.
