### PR TITLE
Fail if `poetry.lock` has fallen out of sync with `pyproject.toml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,16 @@ runs:
         path: ${{ steps.poetry-venvs.outputs.dir }}
         key: poetry-venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
+    - name: Check that the poetry lockfile is up to date
+      # This is rather hacky. We look for the warning message in poetry's
+      # output. We really want to use `poetry lock --check`, but that is only
+      # available in poetry 1.2.
+      # https://github.com/python-poetry/poetry/issues/1406
+      run: >-
+        poetry export --without-hashes | (! grep "The lock file is not up to date") ||
+        (echo pyproject.toml was updated without running \`poetry lock --no-update\`. && false)
+      shell: bash
+
     - name: Install dependencies
       if: "${{ steps.poetry-venv-cache.outputs.cache-hit != 'true' }}"
       run: poetry install --no-interaction --no-root


### PR DESCRIPTION
Signed-off-by: Sean Quah <seanq@element.io>

Example of a failing run: https://github.com/matrix-org/synapse/runs/5720207599?check_suite_focus=true#step:3:64
Example of a passing run: https://github.com/matrix-org/synapse/runs/5720264165?check_suite_focus=true#step:3:61