### PR TITLE
Install deps and project in one go

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,19 +79,14 @@ runs:
         (echo pyproject.toml was updated without running \`poetry lock --no-update\`. && false)
       shell: bash
 
-    - name: Install base dependencies only
-      if: steps.poetry-venv-cache.outputs.cache-hit != 'true' && inputs.extras == ''
+    - name: Install project (no extras)
+      if: inputs.extras == ''
       run: poetry install --no-interaction --no-root
       shell: bash
 
-    - name: Install poetry with --extras=${{ inputs.extras }}
-      if: steps.poetry-venv-cache.outputs.cache-hit != 'true' && inputs.extras != ''
-      run: poetry install --no-interaction --no-root --extras="${{ inputs.extras }}"
-      shell: bash
-
-    # (Not sure if this is needed if there's a cache hit?)
-    - name: Install project
-      run: poetry install --no-interaction
+    - name: Install project with --extras=${{ inputs.extras }}
+      if: inputs.extras != ''
+      run: poetry install --no-interaction --extras="${{ inputs.extras }}"
       shell: bash
 
     # For debugging---let's just check what we're working with.

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,14 @@ runs:
       # output. We really want to use `poetry lock --check`, but that is only
       # available in poetry 1.2.
       # https://github.com/python-poetry/poetry/issues/1406
+      #
+      # Note that the error message has changed with Poetry 1.2 to
+      #     Warning: poetry.lock is not consistent with pyproject.toml. You may be
+      #     getting improper dependencies. Run poetry lock [--no-update] to fix it.
+      # So this check fails on Poetry 1.2. But that version of poetry wants to change
+      # the lockfile to include versions of setuptools for each dependency. So it's
+      # convenient to leave this as-is, unless we want to change to use Poetry 1.2 by
+      # default in the future.
       run: >-
         poetry export --without-hashes | (! grep "The lock file is not up to date") ||
         (echo pyproject.toml was updated without running \`poetry lock --no-update\`. && false)


### PR DESCRIPTION
This works around a change in poetry 1.2; see explanation here:
matrix-org/synapse#12626 (comment)

I had originally made the "install deps" and "install project" steps
separate, to allow us to skip the installing deps bit if there was a
cache hit. I I don't mind losing this, for two reasons:

1. Maintaining that approach would now be painful because I'd
need two different `poetry install` invocations: one with extras and one
without.
2. From very rough testing, I'm not convinced we saved more than 1 or 2 seconds anyway.