### PR TITLE
Fix being unable to install with no `extras`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
 
     - name: Install project (no extras)
       if: inputs.extras == ''
-      run: poetry install --no-interaction --no-root
+      run: poetry install --no-interaction
       shell: bash
 
     - name: Install project with --extras=${{ inputs.extras }}


### PR DESCRIPTION
Regression introduced in #4, see https://github.com/matrix-org/setup-python-poetry/pull/4#discussion_r866423755

Tested
- on https://github.com/matrix-org/synapse/pull/12650
- at commit https://github.com/matrix-org/synapse/pull/12650/commits/ec1befd5a3cb5acc2ab3875c86df161437503e0f, which will soon be force-pushed away
- in this CI run: https://github.com/matrix-org/synapse/runs/6316088796?check_suite_focus=true