### PR TITLE
Update default poetry version to 1.2.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   poetry-version:
     description: Poetry version to install via pip.
     required: false
-    default: "1.1.12"
+    default: "1.2.0"
   extras:
     description: >
       If present, a space separated list of extras to pass to


### PR DESCRIPTION
Mostly as this will make my life easier for adding in Rust, where in poetry 1.1.* you need to manually upgrade `setuptools`