### PR TITLE
Deal with Github Actions deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - name: Setup Python
       id: setup-python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Restore/cache poetry installation
       id: poetry-install-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.site-user-base.outputs.dir }}
         key: poetry-install-cache-${{ steps.setup-python.outputs.python-version }}-${{ inputs.poetry-version }}
@@ -64,7 +64,7 @@ runs:
 
     - name: Restore/cache poetry venv
       id: poetry-venv-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.poetry-venvs.outputs.dir }}
         key: poetry-venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-${{ inputs.extras }}

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
     # https://github.com/snok/install-poetry/blob/main/README.md#caching-the-poetry-installation
     - name: Locate user site
       id: site-user-base
-      run: echo "::set-output name=dir::$(python -m site --user-base)"
+      run: echo "dir=$(python -m site --user-base)" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Restore/cache poetry installation
@@ -59,7 +59,7 @@ runs:
     # Again, we're following snok/install-poetry's README.
     - name: Locate poetry venv
       id: poetry-venvs
-      run: echo "::set-output name=dir::$(python -m poetry config virtualenvs.path)"
+      run: echo "dir=$(python -m poetry config virtualenvs.path)" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Restore/cache poetry venv


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ says "stuff is deprecated and will be turned off at some point". No urgency as such, but without doing this we're going to get warning messages all over the place whenever we use this action.

See https://github.com/matrix-org/synapse/issues/14203

TODO:
- need to run a Synapse PR against this branch to check it all works ok.
  - https://github.com/matrix-org/synapse/actions/runs/3269664704/jobs/5377424235 looked fine and had fewer warnings
- merge
- make a release tag
- force push v1 tag to point at it