### PR TITLE
Use poetry 1.2.2 by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   poetry-version:
     description: Poetry version to install via pip.
     required: false
-    default: "1.2.0"
+    default: "1.2.2"
   extras:
     description: >
       If present, a space separated list of extras to pass to

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: Setup Python and Poetry
 description: Setup Python and Poetry. Cribbed from snok/install-poetry.
 inputs:
   python-version:
-    description: Python version to pass to actions/setup-python@v2.
+    description: Python version to pass to actions/setup-python@v4.
     required: false
     default: "3.x"
   poetry-version:


### PR DESCRIPTION
AFAICS from https://github.com/python-poetry/poetry/releases this is
backwards-compatible with 1.2.x. Crucially, it's also
forwards-compatible with 1.3.x's new lockfile format (see
https://github.com/python-poetry/poetry/pull/6608).