### PR TITLE
Only hash ./poetry.lock to compute the cache key for venvs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ steps.poetry-venvs.outputs.dir }}
-        key: poetry-venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-${{ inputs.extras }}
+        key: poetry-venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-${{ inputs.extras }}
 
     - name: Check that the poetry lockfile is up to date
       # This is rather hacky. We look for the warning message in poetry's


### PR DESCRIPTION
This avoids the post run step failing when a test creates unreadable
files or directories within the working directory.

Signed-off-by: Sean Quah <seanq@matrix.org>
