### PR TITLE
Include OS version in cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The Python and Poetry versions to are configurable: see `action.yaml` for detail
 
 This particular action is loosely based on [`snok/install-poetry`](https://github.com/snok/install-poetry): in particular, the advice from its README on handling caching.
 
+# Requirements
+
+This action is only usable on Linux-based systems.
+
 # Releasing
 
 Follow the advice given on the [backend-meta](https://github.com/matrix-org/backend-meta#releases) repo.

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,15 @@ inputs:
 runs:
   using: composite
   steps:
+    # We want to include the OS version in the cache key. We do this by reading
+    # `/etc/os-release` and picking some suitable values.
+    - name: Get OS version
+      id: get-os-version
+      run: |
+        source /etc/os-release
+        echo "cache_os_key=$ID-$VERSION_ID" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Setup Python
       id: setup-python
       uses: actions/setup-python@v4
@@ -60,7 +69,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ steps.site-user-base.outputs.dir }}
-        key: poetry-install-cache-${{ steps.setup-python.outputs.python-version }}-${{ inputs.poetry-version }}
+        key: poetry-install-cache-${{ steps.get-os-version.outputs.cache_os_key }}-${{ steps.setup-python.outputs.python-version }}-${{ inputs.poetry-version }}
 
     - name: Install poetry from scratch
       if: "${{ steps.poetry-install-cache.outputs.cache-hit != 'true' }}"


### PR DESCRIPTION
This is so that the caches aren't reused when the runner images are updated.

We do assume we're on linux, but I don't think we run this on other OS.