### PR TITLE
Add `working-directory` support to GitHub CI action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: Setup Python and Poetry
 description: Setup Python and Poetry. Cribbed from snok/install-poetry.
 inputs:
+  working-directory:
+    description: Directory where the action will execute its commands. Defaults to repository root.
+    required: false
+    default: "./"
   python-version:
     description: Python version to pass to actions/setup-python@v4.
     required: false
@@ -33,6 +37,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Move to the working directory
+      run: cd ${{ inputs.working-directory }}
+      shell: bash
     - name: Setup Python
       id: setup-python
       uses: actions/setup-python@v4

--- a/action.yml
+++ b/action.yml
@@ -37,9 +37,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Move to the working directory
-      run: cd ${{ inputs.working-directory }}
-      shell: bash
     - name: Setup Python
       id: setup-python
       uses: actions/setup-python@v4
@@ -49,6 +46,7 @@ runs:
     - name: Check for poetry lock
       run: "test -f poetry.lock || (echo No lock file! && false)"
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     # Install poetry. It takes ~10seconds for a clean pip install, most of which is
     # the installation rather than the downloading. So instead, we cache the user-base
@@ -80,6 +78,7 @@ runs:
       id: poetry-venvs
       run: echo "dir=$(python -m poetry config virtualenvs.path)" >> "$GITHUB_OUTPUT"
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Restore/cache poetry venv
       id: poetry-venv-cache
@@ -105,17 +104,20 @@ runs:
         poetry export --without-hashes | (! grep "The lock file is not up to date") ||
         (echo pyproject.toml was updated without running \`poetry lock --no-update\`. && false)
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Install project (no extras or groups)
       if: inputs.extras == '' && inputs.groups == ''
       run: poetry install -vv --no-interaction ${{ inputs.install-project != 'true' && '--no-root' || '' }}
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Install project with --extras=${{ inputs.extras }} --with=${{ inputs.groups }}
       if: inputs.extras != '' || inputs.groups != ''
       # (Empty groups lists are fine.)
       run: poetry install -vv --no-interaction ${{ inputs.extras != '' && format('--extras="{0}"', inputs.extras) || '' }} --with="${{ inputs.groups }}" ${{ inputs.install-project != 'true' && '--no-root' || '' }}
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     # For debugging---let's just check what we're working with.
     - name: Dump virtual environment
@@ -123,3 +125,4 @@ runs:
         poetry env info
         poetry run pip list
       shell: bash
+      working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Add `working-directory` support. Useful in monorepos where there are multiple projects in one repo and you want to run CI against a specific project in a sub-directory.

This is necessary because the built-in GitHub CI [`working-directory`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunworking-directory) config doesn't apply to steps that have `uses`.

Usage:

`synapse_modules.yml`
```yaml
name: Linting and Tests (Synapse modules)
on:
  workflow_dispatch:
  push:
    branches: [main]
  pull_request:
    branches: [main]
    types:
      - opened
      - reopened
      - synchronize
      - ready_for_review

defaults:
  run:
    working-directory: synapse-module-vip-only

jobs:
  check-code-style:
    name: Check code style
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Setup Poetry
        uses: madlittlemods/fork-setup-python-poetry@madlittlemods/work-directory
        with:
          # Move the working directory to the Synapse module's root (where the
          # `pyproject.toml` is).
          working-directory: ./synapse-module-vip-only
          # We have seen odd mypy failures that were resolved when we started
          # installing the project again:
          # https://github.com/matrix-org/synapse/pull/15376#issuecomment-1498983775
          # To make CI green, err towards caution and install the project.
          install-project: "true"
      - run: poetry run black --check --diff synapse_module_vip_only tests
      - run: poetry run ruff --diff synapse_module_vip_only tests
```


### Dev notes

 - https://stackoverflow.com/questions/58139175/running-actions-in-another-directory
 - https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/setting-a-default-shell-and-working-directory
 - https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runsstepsworking-directory
 - https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunworking-directory

Related:

 - https://github.com/actions/checkout/issues/1430#issuecomment-1756326892