### PR TITLE
poetry: fix venv location

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
     # Again, we're following snok/install-poetry's README.
     - name: Locate poetry venv
       id: poetry-venvs
-      run: echo "dir=$(python -m poetry config virtualenvs.path)" >> "$GITHUB_OUTPUT"
+      run: echo "dir=$(python -m poetry env info -p)" >> "$GITHUB_OUTPUT"
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,8 @@ runs:
     # Again, we're following snok/install-poetry's README.
     - name: Locate poetry venv
       id: poetry-venvs
-      run: echo "dir=$(python -m poetry env info -p)" >> "$GITHUB_OUTPUT"
+      run: |
+        echo "dir=$(python -m poetry env info -p || echo $(pwd)/.venv)" >> "$GITHUB_OUTPUT"
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 


### PR DESCRIPTION
We see problems with poetry 1.8.5 when using this action : 

```
Post job cleanup.
Post job cleanup.
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
Post job cleanup.
Cache hit occurred on the primary key poetry-install-cache-3.13.2-1.8.5, not saving cache.
Post job cleanup.
```

It is indeed fixing it : 

https://github.com/element-hq/ess-helm/actions/runs/13413564634/job/37468906955?pr=214

```
Post job cleanup.
Post job cleanup.
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/ess-helm/ess-helm --files-from manifest.txt --use-compress-program zstdmt
Sent 61997056 of 80642270 (76.9%), 59.1 MBs/sec
Sent 80642270 of 80642270 (100.0%), 38.4 MBs/sec
Cache saved with key: poetry-venv-Linux-3.13.2-777e68b7faa091a86e83fdcdb2ba94036bd213c5d24ffcd455c9c6e89abe9d4f-
Post job cleanup.
Cache hit occurred on the primary key poetry-install-cache-3.13.2-1.8.5, not saving cache.
Post job cleanup.
```