### PR TITLE
v2: Switch to Poetry 2 and use poetry check --lock instead of previous poetry export workaround

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,17 +92,14 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - name: Install project (no extras or groups)
-      if: inputs.extras == '' && inputs.groups == ''
-      run: poetry install -vv --no-interaction ${{ inputs.install-project != 'true' && '--no-root' || '' }}
+    - name: Install project
+      run: poetry install -vv --no-interaction ${ARG_EXTRAS:+--extras="$ARG_EXTRAS"} ${ARG_GROUPS:+--with="$ARG_GROUPS"} ${ARG_INSTALL:+"$ARG_INSTALL"}
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
-
-    - name: Install project with --extras=${{ inputs.extras }} --with=${{ inputs.groups }}
-      if: inputs.extras != '' || inputs.groups != ''
-      # (Empty groups lists are fine.)
-      run: poetry install -vv --no-interaction ${{ inputs.extras != '' && format('--extras="{0}"', inputs.extras) || '' }} --with="${{ inputs.groups }}" ${{ inputs.install-project != 'true' && '--no-root' || '' }}
-      shell: bash
+      env:
+        # we pass these as env vars to make sure these values don't get expanded as extra arguments or shell directives
+        ARG_EXTRAS: "${{ inputs.extras }}"
+        ARG_GROUPS: "${{ inputs.groups }}"
+        ARG_INSTALL: "${{ inputs.install-project != 'true' && '--no-root' || '' }}"
       working-directory: ${{ inputs.working-directory }}
 
     # For debugging---let's just check what we're working with.

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   poetry-version:
     description: Poetry version to install via pip.
     required: false
-    default: "1.2.2"
+    default: "2.1.1"
   extras:
     description: >
       If present, a space-separated list of extras to pass to

--- a/action.yml
+++ b/action.yml
@@ -88,21 +88,7 @@ runs:
         key: poetry-venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-${{ inputs.extras }}
 
     - name: Check that the poetry lockfile is up to date
-      # This is rather hacky. We look for the warning message in poetry's
-      # output. We really want to use `poetry lock --check`, but that is only
-      # available in poetry 1.2.
-      # https://github.com/python-poetry/poetry/issues/1406
-      #
-      # Note that the error message has changed with Poetry 1.2 to
-      #     Warning: poetry.lock is not consistent with pyproject.toml. You may be
-      #     getting improper dependencies. Run poetry lock [--no-update] to fix it.
-      # So this check fails on Poetry 1.2. But that version of poetry wants to change
-      # the lockfile to include versions of setuptools for each dependency. So it's
-      # convenient to leave this as-is, unless we want to change to use Poetry 1.2 by
-      # default in the future.
-      run: >-
-        poetry export --without-hashes | (! grep "The lock file is not up to date") ||
-        (echo pyproject.toml was updated without running \`poetry lock --no-update\`. && false)
+      run: poetry check --lock
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 


### PR DESCRIPTION
This PR will be the first for the v2 release of this action.

v2 of this action switches to Poetry 2, which is a breaking change as some commands and options stop existing.