### PR TITLE
allow loading poetry path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,11 @@ inputs:
       deps.
     required: false
     default: "true"
+  load-poetry-path:
+    description: >
+      Set to "true" to add the path to the poetry executable to the PATH.
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -111,6 +116,11 @@ runs:
         ARG_GROUPS: "${{ inputs.groups }}"
         ARG_INSTALL: "${{ inputs.install-project != 'true' && '--no-root' || '' }}"
       working-directory: ${{ inputs.working-directory }}
+
+    - name: Load poetry path
+      run: |
+        echo "$(poetry env info -p)/bin" >> "${GITHUB_PATH}"
+      if: "${{ inputs.load-poetry-path == 'true' }}"
 
     # For debugging---let's just check what we're working with.
     - name: Dump virtual environment


### PR DESCRIPTION
This allows to call commands installed through poetry without going through `python -m <module>..`

This is used extensively in [ESS-Helm](https://github.com/element-hq/ess-helm) repo.