### PR TITLE
Enable caching of virtual environment install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,9 +86,17 @@ runs:
     - name: Locate poetry venv
       id: poetry-venvs
       run: |
-        echo "dir=$(python -m poetry env info -p || echo $(pwd)/.venv)" >> "$GITHUB_OUTPUT"
+        echo "dir=$(echo $(pwd)/.venv)" >> "$GITHUB_OUTPUT"
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+
+    # The venv dir can move based on the version of python used. Just force to always use the
+    # 'in-tree' venv so it is always in the same place. Otherwise, the virtual env dir will not
+    # exist or be definable until the installation of the project has begun and will be uncacheable.
+    - name: Configure poetry venv location
+      shell: bash
+      run: |
+        poetry config virtualenvs.in-project true
 
     - name: Restore/cache poetry venv
       id: poetry-venv-cache


### PR DESCRIPTION
Normally poetry installs a project into a randomiish directory of the sort:
`/home/runner/.cache/pypoetry/virtualenvs/matrix-synapse-pswDeSvb-py3.13`
The tough part there is the hashy looking code and the python version change with each version of python. Since the cache is keyed by python version/extras installed/hash of poetry.lock file, it seems fine to just install the dependencies and project into a known 'never changing' spot, like the `.venv` directory inside the project. 

Seems to save about 30 seconds to a minute in some 'ad-hoc' testing of installing during several synapse CI test runs