### PR TITLE
fix: Pre-create the virtual environment directory so locating it will succeed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,12 @@ runs:
       run: python -m pip install --user poetry==${{ inputs.poetry-version }}
       shell: bash
 
+    - name: Create virtual env directory
+      shell: bash
+      # This will create the directory but not actually activate the environment. Now the poetry env info -p command
+      # will actually find something and not fall back to .venv. This subcommand was introduced in poetry v2.0.0
+      run: poetry env activate
+
     # Poetry manages a virtualenv for us. We're going to cache that too.
     # Again, we're following snok/install-poetry's README.
     - name: Locate poetry venv

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,7 @@ runs:
       shell: bash
       # This will create the directory but not actually activate the environment. Now the poetry env info -p command
       # will actually find something and not fall back to .venv. This subcommand was introduced in poetry v2.0.0
+      # Note: This is required for venv caching to actually work.
       run: poetry env activate
 
     # Poetry manages a virtualenv for us. We're going to cache that too.


### PR DESCRIPTION
The step that locates the poetry virtual environment has a command that does nothing if the directory does not exist yet. `poetry env info -p` returns nothing at this point. After the directory is created, then it will actually return something useful. Here is what it looks like(in it's more full form):

```
jason@ploitari:~/dev/matrix-org/synapse$ poetry env info

Virtualenv
Python:         3.13.7
Implementation: CPython
Path:           NA
Executable:     NA

Base
Platform:   linux
OS:         posix
Python:     3.13.7
Path:       /usr
Executable: /usr/bin/python3.13
jason@ploitari:~/dev/matrix-org/synapse$ poetry env activate
Creating virtualenv matrix-synapse-OVxLbJQ2-py3.13 in /home/jason/.cache/pypoetry/virtualenvs
source /home/jason/.cache/pypoetry/virtualenvs/matrix-synapse-OVxLbJQ2-py3.13/bin/activate
jason@ploitari:~/dev/matrix-org/synapse$ poetry env activate
source /home/jason/.cache/pypoetry/virtualenvs/matrix-synapse-OVxLbJQ2-py3.13/bin/activate
jason@ploitari:~/dev/matrix-org/synapse$ poetry env info

Virtualenv
Python:         3.13.7
Implementation: CPython
Path:           /home/jason/.cache/pypoetry/virtualenvs/matrix-synapse-OVxLbJQ2-py3.13
Executable:     /home/jason/.cache/pypoetry/virtualenvs/matrix-synapse-OVxLbJQ2-py3.13/bin/python
Valid:          True

Base
Platform:   linux
OS:         posix
Python:     3.13.7
Path:       /usr
Executable: /usr/bin/python3.13
jason@ploitari:~/dev/matrix-org/synapse$ 
```
Notice the line that starts with "Creating virtualenv...". And how the `Path` line in the upper and lower sections differ.

I was able to run some test samples in my own repo fork. I usually use the Typechecking job as a good example. Watch for the Setup Poetry step. I have taken the liberty of linking the line in the Setup Poetry step where the directory is created

Synapse test run example before:
https://github.com/realtyem/synapse/actions/runs/21014074159/job/60415412788#step:5:176
Synapse test run example after:
https://github.com/realtyem/synapse/actions/runs/21014855960/job/60417776740#step:5:117

As you can see in the `actions/cache` collapsed section, it is using the correct virtualenv directory now. On the "after" run, in `Post Setup Poetry`, you can see it was trying to save the cache but another task was already uploading it. Found it [here](https://github.com/realtyem/synapse/actions/runs/21014855960/job/60417776730#step:9:5) if it is of interest.

Bonus: Synapse test run example where the cache is restored from: https://github.com/realtyem/synapse/actions/runs/21015568055/job/60419961373#step:5:155
